### PR TITLE
hal: infineon: add hal agnostic layer WHD 

### DIFF
--- a/mtb-hal-cat1/source/cyhal_sdhc.c
+++ b/mtb-hal-cat1/source/cyhal_sdhc.c
@@ -2687,6 +2687,8 @@ static cy_rslt_t _cyhal_sdio_init_common(cyhal_sdio_t *obj, const cyhal_sdio_con
     CY_ASSERT(NULL != cfg->host_config);
     CY_ASSERT(NULL != cfg->card_config);
 
+    cy_rslt_t result = CY_RSLT_SUCCESS;
+
     _cyhal_sdxx_t *sdxx = &(obj->sdxx);
     sdxx->obj = obj;
     sdxx->is_sdio = true;
@@ -2724,12 +2726,15 @@ static cy_rslt_t _cyhal_sdio_init_common(cyhal_sdio_t *obj, const cyhal_sdio_con
     cyhal_gpio_t data[4];
     memcpy(data, cfg->gpios.data, sizeof(cfg->gpios.data));
 
-    cy_rslt_t result = _cyhal_sdxx_setup_pin(sdxx, cmd, cyhal_pin_map_sdhc_card_cmd,
-        CYHAL_PIN_MAP_DRIVE_MODE_SDHC_CARD_CMD,
-        _CYHAL_SDHC_ELEM_COUNT(cyhal_pin_map_sdhc_card_cmd), &(sdxx->pin_cmd), _CYHAL_SDHC_NOT_WEAK_FUNC,
-        !sdxx->dc_configured);
-
-    if (CY_RSLT_SUCCESS == result)
+    if (NC != sdxx->pin_cmd)
+    {
+    		result = _cyhal_sdxx_setup_pin(sdxx, cmd, cyhal_pin_map_sdhc_card_cmd,
+			CYHAL_PIN_MAP_DRIVE_MODE_SDHC_CARD_CMD,
+			_CYHAL_SDHC_ELEM_COUNT(cyhal_pin_map_sdhc_card_cmd), &(sdxx->pin_cmd), _CYHAL_SDHC_NOT_WEAK_FUNC,
+			!sdxx->dc_configured);
+    }
+    
+    if ((NC != sdxx->pin_clk) && (result == CY_RSLT_SUCCESS))
     {
         result = _cyhal_sdxx_setup_pin(sdxx, clk, cyhal_pin_map_sdhc_clk_card,
             CYHAL_PIN_MAP_DRIVE_MODE_SDHC_CLK_CARD,
@@ -2737,7 +2742,7 @@ static cy_rslt_t _cyhal_sdio_init_common(cyhal_sdio_t *obj, const cyhal_sdio_con
             !sdxx->dc_configured);
     }
 
-    if (CY_RSLT_SUCCESS == result)
+    if ((NC != obj->pin_data0) && (result == CY_RSLT_SUCCESS))
     {
         result = _cyhal_sdxx_setup_pin(sdxx, data[0], cyhal_pin_map_sdhc_card_dat_3to0,
             CYHAL_PIN_MAP_DRIVE_MODE_SDHC_CARD_DAT_3TO0,
@@ -2745,7 +2750,7 @@ static cy_rslt_t _cyhal_sdio_init_common(cyhal_sdio_t *obj, const cyhal_sdio_con
             !sdxx->dc_configured);
     }
 
-    if (CY_RSLT_SUCCESS == result)
+    if ((NC != obj->pin_data1) && (result == CY_RSLT_SUCCESS))
     {
         result = _cyhal_sdxx_setup_pin(sdxx, data[1], cyhal_pin_map_sdhc_card_dat_3to0,
             CYHAL_PIN_MAP_DRIVE_MODE_SDHC_CARD_DAT_3TO0,
@@ -2753,7 +2758,7 @@ static cy_rslt_t _cyhal_sdio_init_common(cyhal_sdio_t *obj, const cyhal_sdio_con
             !sdxx->dc_configured);
     }
 
-    if (CY_RSLT_SUCCESS == result)
+    if ((NC != obj->pin_data2) && (result == CY_RSLT_SUCCESS))
     {
         result = _cyhal_sdxx_setup_pin(sdxx, data[2], cyhal_pin_map_sdhc_card_dat_3to0,
             CYHAL_PIN_MAP_DRIVE_MODE_SDHC_CARD_DAT_3TO0,
@@ -2761,7 +2766,7 @@ static cy_rslt_t _cyhal_sdio_init_common(cyhal_sdio_t *obj, const cyhal_sdio_con
             !sdxx->dc_configured);
     }
 
-    if (CY_RSLT_SUCCESS == result)
+    if ((NC != obj->pin_data3) && (result == CY_RSLT_SUCCESS))
     {
         result = _cyhal_sdxx_setup_pin(sdxx, data[3], cyhal_pin_map_sdhc_card_dat_3to0,
             CYHAL_PIN_MAP_DRIVE_MODE_SDHC_CARD_DAT_3TO0,

--- a/wifi-host-driver/WiFi_Host_Driver/inc/whd_types.h
+++ b/wifi-host-driver/WiFi_Host_Driver/inc/whd_types.h
@@ -20,15 +20,24 @@
  *
  */
 
-#include <stdint.h>
-
-#include "cybsp.h"
-#include "cy_result.h"
-#include "cyhal_hw_types.h"
-#include "cyhal_gpio.h"
-
 #ifndef INCLUDED_WHD_TYPES_H_
 #define INCLUDED_WHD_TYPES_H_
+
+#include <stdint.h>
+#include "cybsp.h"
+#include "cy_result.h"
+
+#ifndef WHD_USE_CUSTOM_HAL_IMPL
+	#include "cyhal_hw_types.h"
+	#include "cyhal_gpio.h"
+#if (CYBSP_WIFI_INTERFACE_TYPE == CYBSP_SDIO_INTERFACE)
+	#include "cyhal_sdio.h"
+#elif (CYBSP_WIFI_INTERFACE_TYPE == CYBSP_SPI_INTERFACE)
+	#include "cyhal_spi.h"
+#elif (CYBSP_WIFI_INTERFACE_TYPE == CYBSP_M2M_INTERFACE)
+	#include "cyhal_m2m.h"
+#endif
+#endif /* ifndef WHD_USE_CUSTOM_HAL_IMPL */
 
 #ifdef __cplusplus
 extern "C"
@@ -96,6 +105,28 @@ typedef struct wl_pkt_filter_stats whd_pkt_filter_stats_t;
 typedef struct whd_tko_retry whd_tko_retry_t;
 typedef struct whd_tko_connect whd_tko_connect_t;
 typedef struct whd_tko_status whd_tko_status_t;
+
+#ifndef WHD_USE_CUSTOM_HAL_IMPL
+#define WHD_NC_PIN_VALUE CYHAL_NC_PIN_VALUE
+typedef cyhal_gpio_t whd_gpio_t;
+typedef cyhal_gpio_drive_mode_t whd_gpio_drive_mode_t;
+#if (CYBSP_WIFI_INTERFACE_TYPE == CYBSP_SDIO_INTERFACE)
+typedef cyhal_sdio_t whd_sdio_t;
+#elif (CYBSP_WIFI_INTERFACE_TYPE == CYBSP_SPI_INTERFACE)
+typedef cyhal_spi_t whd_spi_t;
+#elif (CYBSP_WIFI_INTERFACE_TYPE == CYBSP_M2M_INTERFACE)
+typedef cyhal_m2m_t whd_m2m_t;
+#endif
+#else
+#define WHD_NC_PIN_VALUE	NULL
+typedef void* whd_gpio_t;
+typedef uint8_t whd_gpio_drive_mode_t;
+typedef void* whd_sdio_t;
+typedef void* whd_spi_t;
+typedef void* whd_m2m_t;
+#endif /* ifndef WHD_USE_CUSTOM_HAL_IMPL */
+
+
 /** @endcond */
 /******************************************************
 *                    Constants
@@ -1154,11 +1185,11 @@ typedef struct
  */
 typedef struct whd_oob_config
 {
-    cyhal_gpio_t host_oob_pin;          /**< Host-side GPIO pin selection */
+    whd_gpio_t host_oob_pin;          /**< Host-side GPIO pin selection */
     uint8_t dev_gpio_sel;               /**< WiFi device-side GPIO pin selection (must be zero) */
     whd_bool_t is_falling_edge;         /**< Interrupt trigger (polarity) */
     uint8_t intr_priority;              /**< OOB interrupt priority */
-    cyhal_gpio_drive_mode_t drive_mode; /**< Host-side GPIO pin drive mode */
+    whd_gpio_drive_mode_t drive_mode;   /**< Host-side GPIO pin drive mode */
     whd_bool_t init_drive_state;        /**< Host-side GPIO pin initial drive state */
 } whd_oob_config_t;
 

--- a/wifi-host-driver/WiFi_Host_Driver/inc/whd_wifi_api.h
+++ b/wifi-host-driver/WiFi_Host_Driver/inc/whd_wifi_api.h
@@ -81,7 +81,7 @@ extern uint32_t whd_init(whd_driver_t *whd_driver_ptr, whd_init_config_t *whd_in
  *
  *  @return WHD_SUCCESS or Error code
  */
-extern uint32_t whd_bus_sdio_attach(whd_driver_t whd_driver, whd_sdio_config_t *whd_config, cyhal_sdio_t *sdio_obj);
+extern uint32_t whd_bus_sdio_attach(whd_driver_t whd_driver, whd_sdio_config_t *whd_config, whd_sdio_t *sdio_obj);
 
 /** Detach the WLAN Device to a specific SDIO bus
  *
@@ -98,7 +98,7 @@ extern void whd_bus_sdio_detach(whd_driver_t whd_driver);
  *
  *  @return WHD_SUCCESS or Error code
  */
-extern uint32_t whd_bus_spi_attach(whd_driver_t whd_driver, whd_spi_config_t *whd_config, cyhal_spi_t *spi_obj);
+extern uint32_t whd_bus_spi_attach(whd_driver_t whd_driver, whd_spi_config_t *whd_config, whd_spi_t *spi_obj);
 
 /** Detach the WLAN Device to a specific SPI bus
  *
@@ -115,7 +115,7 @@ extern void whd_bus_spi_detach(whd_driver_t whd_driver);
  *
  *  @return WHD_SUCCESS or Error code
  */
-extern uint32_t whd_bus_m2m_attach(whd_driver_t whd_driver, whd_m2m_config_t *whd_config, cyhal_m2m_t *m2m_obj);
+extern uint32_t whd_bus_m2m_attach(whd_driver_t whd_driver, whd_m2m_config_t *whd_config, whd_m2m_t *m2m_obj);
 
 /** Detach the WLAN Device to a specific M2M bus
  *

--- a/wifi-host-driver/WiFi_Host_Driver/src/bus_protocols/whd_bus_spi_protocol.c
+++ b/wifi-host-driver/WiFi_Host_Driver/src/bus_protocols/whd_bus_spi_protocol.c
@@ -31,7 +31,6 @@
 
 #include "cy_result.h"
 #include "cyabs_rtos.h"
-#include "cyhal_gpio.h"
 
 #include "whd_thread.h"
 #include "whd_chip.h"
@@ -131,8 +130,7 @@ static const uint8_t whd_bus_gspi_command_mapping[] = { 0, 1 };
 struct whd_bus_priv
 {
     whd_spi_config_t spi_config;
-    cyhal_spi_t *spi_obj;
-
+    whd_spi_t *spi_obj;
 };
 
 /******************************************************
@@ -150,12 +148,16 @@ static whd_result_t whd_bus_spi_download_resource(whd_driver_t whd_driver, whd_r
                                                   whd_bool_t direct_resource, uint32_t address, uint32_t image_size);
 static whd_result_t whd_bus_spi_write_wifi_nvram_image(whd_driver_t whd_driver);
 static whd_result_t whd_bus_spi_set_backplane_window(whd_driver_t whd_driver, uint32_t addr, uint32_t *curbase);
+
+whd_result_t whd_bus_spi_transfer(whd_driver_t whd_driver, const uint8_t *tx, size_t tx_length, uint8_t *rx,
+                                  size_t rx_length, uint8_t write_fill);
+
 /******************************************************
 *             Global Function definitions
 ******************************************************/
 uint32_t whd_bus_spi_bt_packet_available_to_read(whd_driver_t whd_driver);
 
-uint32_t whd_bus_spi_attach(whd_driver_t whd_driver, whd_spi_config_t *whd_spi_config, cyhal_spi_t *spi_obj)
+uint32_t whd_bus_spi_attach(whd_driver_t whd_driver, whd_spi_config_t *whd_spi_config, whd_spi_t *spi_obj)
 {
     struct whd_bus_info *whd_bus_info;
 
@@ -166,7 +168,7 @@ uint32_t whd_bus_spi_attach(whd_driver_t whd_driver, whd_spi_config_t *whd_spi_c
         return WHD_WLAN_BADARG;
     }
 
-    if (whd_spi_config->oob_config.host_oob_pin == CYHAL_NC_PIN_VALUE)
+    if (whd_spi_config->oob_config.host_oob_pin == WHD_NC_PIN_VALUE)
     {
         WPRINT_WHD_ERROR( ("OOB interrupt pin argument must be provided in %s\n", __FUNCTION__) );
         return WHD_BADARG;
@@ -248,6 +250,15 @@ void whd_bus_spi_detach(whd_driver_t whd_driver)
         whd_driver->bus_priv = NULL;
     }
 }
+
+#ifndef WHD_USE_CUSTOM_HAL_IMPL
+whd_result_t whd_bus_spi_transfer(whd_driver_t whd_driver, const uint8_t *tx, size_t tx_length, uint8_t *rx, size_t rx_length,
+                             uint8_t write_fill)
+{
+    return cyhal_spi_transfer(whd_driver->bus_priv->spi_obj, tx, tx_length, rx, rx_length, write_fill);
+}
+#endif /* ifndef WHD_USE_CUSTOM_HAL_IMPL */
+
 
 whd_result_t whd_bus_spi_send_buffer(whd_driver_t whd_driver, whd_buffer_t buffer)
 {
@@ -348,7 +359,7 @@ static whd_result_t whd_bus_spi_transfer_buffer(whd_driver_t whd_driver, whd_bus
     /* Send the data */
     if (direction == BUS_READ)
     {
-        result =  cyhal_spi_transfer(whd_driver->bus_priv->spi_obj, NULL,
+        result =  whd_bus_spi_transfer(whd_driver, NULL,
                                      sizeof(whd_bus_gspi_header_t),
                                      (uint8_t *)gspi_header,
                                      transfer_size, 0);
@@ -356,8 +367,7 @@ static whd_result_t whd_bus_spi_transfer_buffer(whd_driver_t whd_driver, whd_bus
     }
     else
     {
-        result = cyhal_spi_transfer(whd_driver->bus_priv->spi_obj, (uint8_t *)gspi_header, transfer_size, NULL,
-                                    0, 0);
+        result = whd_bus_spi_transfer(whd_driver, (uint8_t *)gspi_header, transfer_size, NULL, 0, 0);
     }
 
     return result;
@@ -572,7 +582,7 @@ whd_result_t whd_bus_spi_init(whd_driver_t whd_driver)
     loop_count = 0;
     do
     {
-        /* Header needs to calculated every time as init_data gets modified in cyhal_spi_transfer() */
+        /* Header needs to calculated every time as init_data gets modified in whd_bus_spi_transfer() */
         *gspi_header =
             ( whd_bus_gspi_header_t )SWAP32_16BIT_PARTS(SWAP32( (uint32_t)( (whd_bus_gspi_command_mapping[(int)BUS_READ]
                                                                              & 0x1) << 31 ) |
@@ -581,7 +591,7 @@ whd_result_t whd_bus_spi_init(whd_driver_t whd_driver)
                                                                 (uint32_t)( (SPI_READ_TEST_REGISTER & 0x1FFFFu) <<
                                                                             11 ) |
                                                                 (uint32_t)( (4u /*size*/ & 0x7FFu) << 0 ) ) );
-        CHECK_RETURN(cyhal_spi_transfer(whd_driver->bus_priv->spi_obj, NULL, sizeof(whd_bus_gspi_header_t),
+        CHECK_RETURN(whd_bus_spi_transfer(whd_driver, NULL, sizeof(whd_bus_gspi_header_t),
                                         init_data, transfer_size, 0) );
         loop_count++;
     } while ( (NULL == memchr(&init_data[4], SPI_READ_TEST_REG_LSB, (size_t)8) ) &&
@@ -741,6 +751,7 @@ whd_result_t whd_bus_spi_init(whd_driver_t whd_driver)
         whd_driver->aligned_addr = NULL;
     }
     CHECK_RETURN(result);
+
     return result;
 }
 
@@ -993,15 +1004,13 @@ whd_result_t whd_bus_spi_transfer_bytes(whd_driver_t whd_driver, whd_bus_transfe
     /* Send the data */
     if (direction == BUS_READ)
     {
-        result = cyhal_spi_transfer(whd_driver->bus_priv->spi_obj, NULL,
-                                    sizeof(whd_bus_gspi_header_t),
-                                    (uint8_t *)gspi_header,
-                                    transfer_size, 0);
+        result = whd_bus_spi_transfer(whd_driver, NULL, sizeof(whd_bus_gspi_header_t),
+                                    (uint8_t *)gspi_header,transfer_size, 0);
     }
     else
     {
-        result = cyhal_spi_transfer(whd_driver->bus_priv->spi_obj, (uint8_t *)gspi_header, transfer_size, NULL,
-                                    0, 0);
+        result = whd_bus_spi_transfer(whd_driver, (uint8_t *)gspi_header, 
+                                      transfer_size, NULL,0, 0);
     }
 
     CHECK_RETURN(result);
@@ -1142,11 +1151,12 @@ uint32_t whd_bus_spi_get_max_transfer_size(whd_driver_t whd_driver)
     return WHD_BUS_SPI_MAX_BACKPLANE_TRANSFER_SIZE;
 }
 
+#ifndef WHD_USE_CUSTOM_HAL_IMPL
 #if (CYHAL_API_VERSION >= 2)
 static void whd_bus_spi_oob_irq_handler(void *arg, cyhal_gpio_event_t event)
 #else
 static void whd_bus_spi_oob_irq_handler(void *arg, cyhal_gpio_irq_event_t event)
-#endif
+#endif /* (CYHAL_API_VERSION >= 2) */
 {
     whd_driver_t whd_driver = (whd_driver_t)arg;
     const whd_oob_config_t *config = &whd_driver->bus_priv->spi_config.oob_config;
@@ -1156,7 +1166,7 @@ static void whd_bus_spi_oob_irq_handler(void *arg, cyhal_gpio_irq_event_t event)
 #else
     const cyhal_gpio_irq_event_t expected_event = (config->is_falling_edge == WHD_TRUE)
                                                   ? CYHAL_GPIO_IRQ_FALL : CYHAL_GPIO_IRQ_RISE;
-#endif
+#endif /* (CYHAL_API_VERSION >= 2) */
     if (event != expected_event)
     {
         WPRINT_WHD_ERROR( ("Unexpected interrupt event %d\n", event) );
@@ -1184,7 +1194,7 @@ whd_result_t whd_bus_spi_irq_register(whd_driver_t whd_driver)
 #else
     cyhal_gpio_register_irq(config->host_oob_pin, WLAN_INTR_PRIORITY, whd_bus_spi_oob_irq_handler,
                             whd_driver);
-#endif
+#endif /* (CYHAL_API_VERSION >= 2) */
     return WHD_TRUE;
 }
 
@@ -1201,9 +1211,10 @@ whd_result_t whd_bus_spi_irq_enable(whd_driver_t whd_driver, whd_bool_t enable)
         (config->is_falling_edge == WHD_TRUE) ? CYHAL_GPIO_IRQ_FALL : CYHAL_GPIO_IRQ_RISE;
 
     cyhal_gpio_irq_enable(config->host_oob_pin, event, (enable == WHD_TRUE) ? true : false);
-#endif
+#endif /* (CYHAL_API_VERSION >= 2) */
     return WHD_TRUE;
 }
+#endif /* ifndef WHD_USE_CUSTOM_HAL_IMPL */
 
 static whd_result_t whd_bus_spi_download_resource(whd_driver_t whd_driver, whd_resource_type_t resource,
                                                   whd_bool_t direct_resource, uint32_t address, uint32_t image_size)


### PR DESCRIPTION
hal: infineon: add hal agnostic layer WHD 

- added possibility to use custom hal (non cyhal) for SDIO/SPI bus.
- update cyhal  to configure SDIO without selecting pins. Pin configuration must be handle by pinctrl.

Signed-off-by: Nazar Palamar <nazar.palamar@infineon.com>
