### PR TITLE
hal: infineon: Add custom HAL support for SPI

### DIFF
--- a/wifi-host-driver/WiFi_Host_Driver/resources/resource_imp/whd_resources.c
+++ b/wifi-host-driver/WiFi_Host_Driver/resources/resource_imp/whd_resources.c
@@ -18,6 +18,8 @@
 /** @file
  * Defines WHD resource functions for BCM943340WCD1 platform
  */
+#include "cmsis_compiler.h"
+#include "cy_utils.h"
 #include "resources.h"
 #include "clm_resources.h"
 #include "wifi_nvram_image.h"
@@ -78,7 +80,8 @@ extern const resource_hnd_t wifi_firmware_image;
 extern const resource_hnd_t wifi_firmware_clm_blob;
 #endif
 
-unsigned char r_buffer[BLOCK_BUFFER_SIZE];
+// Need to be aligned as whd_bus_spi_protocol.c reads a uint32_t
+CY_ALIGN(4) unsigned char r_buffer[BLOCK_BUFFER_SIZE];
 
 #if defined(WHD_DYNAMIC_NVRAM)
 uint32_t dynamic_nvram_size = sizeof(wifi_nvram_image);

--- a/wifi-host-driver/WiFi_Host_Driver/src/bus_protocols/whd_bus_spi_protocol.c
+++ b/wifi-host-driver/WiFi_Host_Driver/src/bus_protocols/whd_bus_spi_protocol.c
@@ -65,7 +65,12 @@
 #define SBSDIO_SB_OFT_ADDR_LIMIT  0x08000
 #define SBSDIO_SB_ACCESS_2_4B_FLAG  0x08000 /* with b15, maps to 32-bit SB access */
 
+#if defined(CONFIG_CYW43439)
+/* Delay before HT is available on the CYW43439 is over 1600 mSec */
+#define HT_AVAIL_TIMEOUT_MS    (2000)
+#else
 #define HT_AVAIL_TIMEOUT_MS    (1000)
+#endif
 
 /* Taken from FALCON_5_90_195_26 dhd/sys/dhd_sdio.c. For 43362, MUST be >= 8 and word-aligned otherwise dongle fw crashes */
 #define SPI_F2_WATERMARK       (32)

--- a/wifi-host-driver/WiFi_Host_Driver/src/bus_protocols/whd_bus_spi_protocol.h
+++ b/wifi-host-driver/WiFi_Host_Driver/src/bus_protocols/whd_bus_spi_protocol.h
@@ -18,7 +18,11 @@
 #include "whd.h"
 #include "whd_bus_protocol_interface.h"
 #include "cy_result.h"
+
+#ifndef WHD_USE_CUSTOM_HAL_IMPL
 #include "cyhal_spi.h"
+#endif /* WHD_USE_CUSTOM_HAL_IMPL */
+
 
 #ifndef INCLUDED_SPI_WHD_BUS_PROTOCOL_H
 #define INCLUDED_SPI_WHD_BUS_PROTOCOL_H
@@ -87,10 +91,12 @@ extern whd_bool_t whd_bus_spi_use_status_report_scheme(whd_driver_t whd_driver);
 extern uint32_t whd_bus_spi_get_max_transfer_size(whd_driver_t whd_driver);
 extern whd_result_t whd_bus_spi_irq_register(whd_driver_t whd_driver);
 extern whd_result_t whd_bus_spi_irq_enable(whd_driver_t whd_driver, whd_bool_t enable);
+#ifndef WHD_USE_CUSTOM_HAL_IMPL
 #if (CYHAL_API_VERSION >= 2)
 extern void whd_bus_spi_irq_handler(void *handler_arg, cyhal_spi_event_t event);
 #else
 extern void whd_bus_spi_irq_handler(void *handler_arg, cyhal_spi_irq_event_t event);
+#endif
 #endif
 /******************************************************
 *             Global variables


### PR DESCRIPTION
* WHD_LINK_MTU needs to be at least 1600 bytes
* r_buffer in whd_resources.c must be aligned on a 32-bit boundary
* The wait loop in whd_bus_spi_protocol.c for HT available needs to be slower
* Elements in whd_bus_spi_protocol.h should be guarded with WHD_USE_CUSTOM_HAL_IMPL