### PR TITLE
hal: infineon: Update bt_stack-integration for 20829

### DIFF
--- a/btstack-integration/COMPONENT_BTSS-IPC/platform/ipc/cybt_bt_task.c
+++ b/btstack-integration/COMPONENT_BTSS-IPC/platform/ipc/cybt_bt_task.c
@@ -70,7 +70,7 @@ extern void cybt_platform_exception_handler(cybt_exception_t error, uint8_t *inf
  *                           Function Definitions
  ******************************************************************************/
 BTSTACK_PORTING_SECTION_BEGIN
-static uint8_t task_queue_utilization(void)
+uint8_t task_queue_utilization(void)
 {
     size_t item_cnt_in_queue = 0;
     cy_rslt_t result;
@@ -310,4 +310,3 @@ void cybt_bttask_deinit(void)
      * Below call will wait on internal semaphore and it will set on cy_rtos_exit_thread() */
     cy_rtos_join_thread(&bt_task);
 }
-

--- a/btstack-integration/COMPONENT_BTSS-IPC/platform/ipc/cybt_platform_hci.c
+++ b/btstack-integration/COMPONENT_BTSS-IPC/platform/ipc/cybt_platform_hci.c
@@ -186,6 +186,11 @@ static void notify_callback_mcu_longmsg(uint32_t * msg)
             /* On FPGA, controller does not send CY_BT_IPC_BOOT_CONFIG_WAIT and directly sends CY_BT_IPC_BOOT_FULLY_UP */
             cybt_platform_msg_to_bt_task(BT_EVT_TASK_BOOT_COMPLETES, IN_ISR);
 #else
+
+#if (defined(COMPONENT_CYW20829B0) || defined(COMPONENT_CYW89829B0))
+            Cy_SysClk_ClkHfSetSource(0U, CY_SYSCLK_CLKHF_IN_CLKPATH0); /* restore to original frequency */
+#endif // (defined(COMPONENT_CYW20829B0) || defined(COMPONENT_CYW89829B0))
+
             cy_rtos_set_semaphore(&hci_cb.boot_fully_up, IN_ISR);
 #endif /* FPGA_TEST_PLATFORM */
             break;
@@ -578,6 +583,8 @@ cybt_result_t cybt_platform_hci_close(void)
         HCIDRV_TRACE_ERROR("MCU Error: Syspm Callback Unregistering failed!\n");
         CY_ASSERT(0);
     }
+
+    cy_rtos_deinit_semaphore(&hci_cb.boot_fully_up);
 
     memset(&hci_cb, 0, sizeof(hci_interface_t));
 


### PR DESCRIPTION
1. most of changest was migrated from latest btstack-integration asset
2. removed static from task_queue_utilization declaration to use it in syspm sleep\deepsleep callback, for checking if we can put host in lpm.