### PR TITLE
hal: infineon: Add option to disable SDIO pullups during SPI sleep

### DIFF
--- a/wifi-host-driver/WHD/COMPONENT_WIFI5/src/whd_chip.c
+++ b/wifi-host-driver/WHD/COMPONENT_WIFI5/src/whd_chip.c
@@ -1259,7 +1259,11 @@ static whd_result_t whd_enable_save_restore(whd_driver_t whd_driver)
         CHECK_RETURN(whd_bus_sleep(whd_driver) );
 
         /* Put SPI interface block to sleep */
+        #ifdef WHD_DISABLE_SDIO_PULLUP_DURING_SPI_SLEEP
+        CHECK_RETURN(whd_bus_write_register_value(whd_driver, BACKPLANE_FUNCTION, SDIO_PULL_UP, (uint8_t)1, 0x0) );
+        #else
         CHECK_RETURN(whd_bus_write_register_value(whd_driver, BACKPLANE_FUNCTION, SDIO_PULL_UP, (uint8_t)1, 0xf) );
+        #endif
 
         whd_driver->chip_info.save_restore_enable = WHD_TRUE;
     }


### PR DESCRIPTION
Currently, the SDIO pullups are always set during SPI sleep. This is a board specific feature which is not always required and can cause issues when interacting with other pull ups and pull downs on the line. This commit adds a macro to disable this feature. Enabling is left as the default so as to prevent a breaking change.

This PR also interacts with #27 to create a setup that works properly for the Pico 2W board in particular. The issue is referenced in this Zephyr PR: https://github.com/zephyrproject-rtos/zephyr/pull/90793 and the macro can be set by Kconfig.

I've tried to keep the default, enabling the pull ups, the same and to give the macro a descriptive name. Happy to make any further changes as required.

Thanks,

Tim