### PR TITLE
hal_infineon: Introduce CYT4DN cat1cm0p blob.

### DIFF
--- a/cat1cm0p/COMPONENT_CAT1C/COMPONENT_CM0P_SLEEP/tviic2d6m_cm0p_sleep.c
+++ b/cat1cm0p/COMPONENT_CAT1C/COMPONENT_CM0P_SLEEP/tviic2d6m_cm0p_sleep.c
@@ -1,0 +1,33 @@
+/*
+Copyright 2025 (c) Infineon Technologies AG
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include <stdint.h>
+#include "cy_device_headers.h"
+
+#if defined(CY_DEVICE_TVIIC2D6M)
+#if defined(__APPLE__) && defined(__clang__)
+__attribute__ ((__section__("__CY_M0P_IMAGE,__cy_m0p_image"), used))
+#elif defined(__GNUC__) || defined(__ARMCC_VERSION)
+__attribute__ ((__section__(".cy_m0p_image"), used))
+#elif defined(__ICCARM__)
+#pragma  location=".cy_m0p_image"
+#else
+#error "An unsupported toolchain"
+#endif
+const uint8_t cy_m0p_image[] = {
+    #include <tviic2d6m_cm0p_sleep.bin.inc>
+};
+#endif /* defined(CY_DEVICE_TVIIC2D6M) */

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -37,6 +37,15 @@ blobs:
     url: https://github.com/Infineon/cat1cm0p/raw/release-v1.7.0/COMPONENT_CAT1A/COMPONENT_CM0P_SLEEP/psoc6_04_cm0p_sleep.bin
     description: "PSoC 6 Cortex M0+ DeepSleep prebuilt image (CM0P_SLEEP)"
     doc-url: https://github.com/Infineon/cat1cm0p
+  # COMPONENT_CAT1C/COMPONENT_CM0P_SLEEP
+  - path: img/cat1cm0p/COMPONENT_CAT1C/COMPONENT_CM0P_SLEEP/tviic2d6m_cm0p_sleep.bin
+    sha256: fc2fd66fa9642fb41a202190a9b9f4e400fc77b4822b293e760d81f284443c57
+    type: img
+    version: '1.9.0'
+    license-path: ./LICENSE.txt
+    url: https://github.com/Infineon/cat1cm0p/raw/release-v1.9.0/COMPONENT_CAT1C/COMPONENT_CM0P_SLEEP/tviic2d6m_cm0p_sleep.bin
+    description: "TRAVEO T2G CYT4DN Cortex M0+ DeepSleep prebuilt image (CM0P_SLEEP)"
+    doc-url: https://github.com/Infineon/cat1cm0p
 
 #wifi-host-driver (firmware and clm blobs)
   #CYW43012 Device


### PR DESCRIPTION
This add the cat1cm0p blob for the CYT4DN. The support is currently in development.