### PR TITLE
whd: Remove cyhal includes in Zephyr build

### DIFF
--- a/whd-expansion/WHD/COMPONENT_WIFI5/src/bus_protocols/whd_bus_sdio_protocol.c
+++ b/whd-expansion/WHD/COMPONENT_WIFI5/src/bus_protocols/whd_bus_sdio_protocol.c
@@ -28,8 +28,10 @@
 #if (CYBSP_WIFI_INTERFACE_TYPE == CYBSP_SDIO_INTERFACE) && !defined(COMPONENT_WIFI_INTERFACE_OCI)
 
 #include "cyabs_rtos.h"
+#ifndef WHD_ZEPHYR
 #include "cyhal_sdio.h"
 #include "cyhal_gpio.h"
+#endif
 
 #include "whd_bus_sdio_protocol.h"
 #include "whd_bus.h"


### PR DESCRIPTION
Stray includes of cyhal broke the build for folks using our wireless parts with non-Infineon microcontrollers when building with Zephyr.

Wrap #include's of cyhal such that they are not included when building for Zephyr.