### PR TITLE
hal_infineon: Introduce Traveo Body Entry 1m cat1cm0p blob.

### DIFF
--- a/cat1cm0p/COMPONENT_CM0P_SLEEP/tviibe1m_cm0p_sleep.c
+++ b/cat1cm0p/COMPONENT_CM0P_SLEEP/tviibe1m_cm0p_sleep.c
@@ -1,0 +1,30 @@
+/*
+Copyright 2025 (c) Infineon Technologies AG
+SPDX-License-Identifier: Apache-2.0
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include <stdint.h>
+#include "cy_device_headers.h"
+
+#if defined(CY_DEVICE_TVIIBE1M)
+#if defined(__APPLE__) && defined(__clang__)
+__attribute__ ((__section__("__CY_M0P_IMAGE,__cy_m0p_image"), used))
+#elif defined(__GNUC__) || defined(__ARMCC_VERSION)
+__attribute__ ((__section__(".cy_m0p_image"), used))
+#elif defined(__ICCARM__)
+#pragma  location=".cy_m0p_image"
+#else
+#error "An unsupported toolchain"
+#endif
+const uint8_t cy_m0p_image[] = {
+    #include <tviibe1m_cm0p_sleep.bin.inc>
+};
+#endif /* defined(CY_DEVICE_TVIIBE1M) */

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -38,6 +38,16 @@ blobs:
     description: "PSoC 6 Cortex M0+ DeepSleep prebuilt image (CM0P_SLEEP)"
     doc-url: https://github.com/Infineon/cat1cm0p
 
+
+  - path: img/cat1cm0p/COMPONENT_CM0P_SLEEP/tviibe1m_cm0p_sleep.bin
+    sha256: 2d3702942ee28d231ae9888d597ed7f77f7ea745993e36630a7f43c33c157557
+    type: img
+    version: '1.9.0'
+    license-path: ./LICENSE.txt
+    url: https://github.com/Infineon/cat1cm0p/raw/release-v1.9.0/COMPONENT_CAT1A/COMPONENT_CM0P_SLEEP/tviibe1m_cm0p_sleep.bin
+    description: "Traveo Body Entry 1M Cortex M0+ DeepSleep prebuilt image (CM0P_SLEEP)"
+    doc-url: https://github.com/Infineon/cat1cm0p
+
 #whd-expansion (firmware and clm blobs)
   #CYW43012 Device
   #firmware


### PR DESCRIPTION
This add the cat1cm0p blob for the Traveo body entry 1m. The support is currently in development.