### PR TITLE
Add scancode license checking

### DIFF
--- a/.github/license_config.yml
+++ b/.github/license_config.yml
@@ -1,0 +1,16 @@
+license:
+  main: apache-2.0
+  report_missing: true
+  category: Permissive
+copyright:
+  check: true
+exclude:
+  extensions:
+    - yml
+    - yaml
+    - html
+    - rst
+    - conf
+    - cfg
+  langs:
+    - HTML

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -1,0 +1,37 @@
+name: Scancode
+
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  scancode_job:
+    runs-on: ubuntu-24.04
+    name: Scan code for licenses
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        fetch-depth: 0
+    - name: Scan the code
+      id: scancode
+      uses: zephyrproject-rtos/action_scancode@23ef91ce31cd4b954366a7b71eea47520da9b380 # v4
+      with:
+        directory-to-scan: 'scan/'
+    - name: Artifact Upload
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+      with:
+        name: scancode
+        path: ./artifacts
+
+    - name: Verify
+      run: |
+        if [ -s ./artifacts/report.txt ]; then
+          report=$(cat ./artifacts/report.txt)
+          report="${report//'%'/'%25'}"
+          report="${report//$'\n'/'%0A'}"
+          report="${report//$'\r'/'%0D'}"
+          echo "::error file=./artifacts/report.txt::$report"
+          exit 1
+        fi


### PR DESCRIPTION
Adds a github action to scan all new files for allowable licenses and license headers.

An inappopriate license should result in a check failing saving us from committing it to the repo by mistake.