### PR TITLE
Asset updates

### DIFF
--- a/mtb-template-pse8xxgp/files/cy_device_headers.h
+++ b/mtb-template-pse8xxgp/files/cy_device_headers.h
@@ -27,10 +27,14 @@
 
 #pragma once
 
-#if defined (COMPONENT_SECURE_DEVICE)
-#include "cy_device_headers_s.h"
+#if defined(PSE846GPS2DBZC4A)
+    #if defined(COMPONENT_SECURE_DEVICE)
+        #include "pse846gps2dbzc4a_s.h"
+    #else
+        #include "pse846gps2dbzc4a.h"
+    #endif
 #else
-#include "cy_device_headers_ns.h"
+    #error "Unsupported PSE84 device."
 #endif
 
 /* [] END OF FILE */


### PR DESCRIPTION
Use the SoC part number preprocessor define to select the correct
device header instead of hardcoding a single variant. This allows
for mtb-template-pse8xxgp to be used by TF-M instead of board
specific BSP asset