### PR TITLE
hal: infineon: Fix I2C repeated start for combined transactions

### DIFF
--- a/mtb-hal-cat1/source/cyhal_i2c.c
+++ b/mtb-hal-cat1/source/cyhal_i2c.c
@@ -858,6 +858,7 @@ cy_rslt_t cyhal_i2c_master_transfer_async(cyhal_i2c_t *obj, uint16_t address, co
             obj->pending = (rx_size)
                 ? _CYHAL_I2C_PENDING_TX_RX
                 : _CYHAL_I2C_PENDING_TX;
+			obj->tx_config.xferPending = (rx_size != 0u);
             Cy_SCB_I2C_MasterWrite(obj->base, &obj->tx_config, &obj->context);
             /* Receive covered by interrupt handler - _cyhal_i2c_irq_handler() */
         }


### PR DESCRIPTION
Set tx_config.xferPending when a read operation follows a write to suppress the STOP condition after TX. This allows the driver to issue a repeated START before the read phase instead of a new START sequence.

This fix is needed for I2C devices like VEML7700 light sensor that require proper repeated start conditions for combined write-read transfers.

This fix is tested with cy8cproto_062_4343w HW.