### PR TITLE
Fix: Remove STACK_SIZE macro in tviic_partition.h

### DIFF
--- a/mtb-template-cat1/files/templates/cat1c/COMPONENT_MTB/HEADER_FILES/tviic_partition.h
+++ b/mtb-template-cat1/files/templates/cat1c/COMPONENT_MTB/HEADER_FILES/tviic_partition.h
@@ -1,7 +1,6 @@
 #if !defined(TVIIC_PARTITION_H)
 #define TVIIC_PARTITION_H
 
-#define STACK_SIZE                      0x1000
 #define RAMVECTORS_ALIGNMENT            128
 
 #define SRAM_START_RESERVE              0


### PR DESCRIPTION
Removed STACK_SIZE macro in `tviic_partition.h` to prevent conflicts of redefinition of `STACK_SIZE` macro in zephyr test suites samples, which makes CI fail in zephyr.

CI Failure logs:
```
INFO    - 3) arch.interrupt on kit_t2g_c2d6m_lite/cyt4dnjbzs/m0p error (Build failure - error: "STACK_SIZE" redefined [-Werror])
INFO    - 4) arch.interrupt.minimallibc on kit_t2g_c2d6m_lite/cyt4dnjbzs/m0p error (Build failure - error: "STACK_SIZE" redefined [-Werror])
INFO    - 5) arch.interrupt.multilevel on kit_t2g_c2d6m_lite/cyt4dnjbzs/m0p error (Build failure - error: "STACK_SIZE" redefined [-Werror])
INFO    - 6) arch.interrupt.multilevel_l3 on kit_t2g_c2d6m_lite/cyt4dnjbzs/m0p error (Build failure - error: "STACK_SIZE" redefined [-Werror])
INFO    - 7) arch.shared_interrupt on kit_t2g_c2d6m_lite/cyt4dnjbzs/m0p error (Build failure - error: "STACK_SIZE" redefined [-Werror])
INFO    - 8) arch.shared_interrupt.lto on kit_t2g_c2d6m_lite/cyt4dnjbzs/m0p error (Build failure - error: "STACK_SIZE" redefined [-Werror])
INFO    - 9) arch.shared_interrupt.lto.speed on kit_t2g_c2d6m_lite/cyt4dnjbzs/m0p error (Build failure - error: "STACK_SIZE" redefined [-Werror])
INFO    - 10) benchmark.kernel.footprints.default on kit_t2g_c2d6m_lite/cyt4dnjbzs/m0p error (Build failure - error: "STACK_SIZE" redefined [-Werror])
```