### PR TITLE
hal: infineon: Update whd-expansion to 1.4.0.370

### DIFF
--- a/whd-expansion/RELEASE.md
+++ b/whd-expansion/RELEASE.md
@@ -1,4 +1,4 @@
-# Wi-Fi Host Driver Expansion (WHDE) Zep-1.2.1
+# Wi-Fi Host Driver Expansion (WHDE) 1.4.0
 Please refer to the [README File](./README.md) and the [WHD API Reference Manual](https://infineon.github.io/wifi-host-driver/html/index.html) for a complete description of the Wi-Fi Host Driver.
 
 ### WIFI6 Supported Chip v4.3.0
@@ -15,7 +15,7 @@ Please refer to the [README File](./README.md) and the [WHD API Reference Manual
 NA
 
 #### CYW55500
-* --- 28.10.522.8 ---
+* --- 28.10.591.6 ---
 
 #### CYW55900
 * --- 28.10.400.2 ---

--- a/whd-expansion/WHD/COMMON/inc/whd_debug.h
+++ b/whd-expansion/WHD/COMMON/inc/whd_debug.h
@@ -19,9 +19,9 @@
 #include <string.h>
 #include "whd.h"
 #include "whd_utils.h"
-#if defined(WHD_CUSTOM_HAL) && defined(IMXRT)
+#if defined(IMXRT)
 #include "fsl_debug_console.h"
-#endif /* WHD_CUSTOM_HAL && IMXRT */
+#endif /* defined(IMXRT) */
 #ifndef INCLUDED_WHD_DEBUG_H
 #define INCLUDED_WHD_DEBUG_H
 
@@ -75,11 +75,11 @@ extern "C"
 #if defined(WHD_LOGGING_BUFFER_ENABLE)
 #define WPRINT_MACRO(args) do { cy_time_t time; cy_rtos_get_time(&time); printf("\n[%lu] " ,(unsigned long)time); printf args; } while (0 == 1)
 #else
-#if defined(WHD_CUSTOM_HAL) && defined(IMXRT)
+#if defined(IMXRT)
 #define WPRINT_MACRO(args) do { cy_time_t time; cy_rtos_get_time(&time); PRINTF("\n[%lu] " ,(unsigned long)time); PRINTF args; } while (0 == 1)
 #else
 #define WPRINT_MACRO(args) do { cy_time_t time; cy_rtos_get_time(&time); printf("\n[%lu] " ,(unsigned long)time); printf args; } while (0 == 1)
-#endif /* WHD_CUSTOM_HAL && IMXRT */
+#endif /* defined(IMXRT) */
 
 #endif
 #endif

--- a/whd-expansion/WHD/COMMON/src/whd_cdc_bdc.c
+++ b/whd-expansion/WHD/COMMON/src/whd_cdc_bdc.c
@@ -56,11 +56,7 @@
 
 #define IOCTL_OFFSET (sizeof(whd_buffer_header_t) + 12 + 16)
 #define WHD_IOCTL_PACKET_TIMEOUT      (0xFFFFFFFF)
-#if (defined(WHD_CUSTOM_HAL) && defined(IMXRT))
-#define WHD_IOCTL_TIMEOUT_MS         (15000)
-#else
 #define WHD_IOCTL_TIMEOUT_MS         (5000)     /** Need to give enough time for coming out of Deep sleep (was 400) */
-#endif /* WHD_CUSTOM_HAL && IMXRT */
 #define WHD_IOCTL_MAX_TX_PKT_LEN     (1500)
 #define ALIGNED_ADDRESS            ( (uint32_t)0x3 )
 

--- a/whd-expansion/WHD/COMPONENT_WIFI6/inc/whd_types.h
+++ b/whd-expansion/WHD/COMPONENT_WIFI6/inc/whd_types.h
@@ -22,6 +22,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <string.h>
 #include "cybsp.h"
 #include "cy_result.h"
 
@@ -1554,6 +1555,14 @@ typedef struct {
     uint8_t *event_data;
     whd_event_header_t *event_header;
 } whd_event_data_t;
+
+typedef struct {
+    uint8_t *req_ies;
+    size_t req_ies_len;
+    uint8_t *resp_ies;
+    size_t resp_ies_len;
+} whd_assoc_info_t;
+
 #ifdef __cplusplus
 }     /* extern "C" */
 #endif

--- a/whd-expansion/WHD/COMPONENT_WIFI6/inc/whd_wifi_api.h
+++ b/whd-expansion/WHD/COMPONENT_WIFI6/inc/whd_wifi_api.h
@@ -1807,6 +1807,15 @@ extern whd_result_t whd_wifi_icmp_echo_req_register_callback(whd_interface_t ifp
  */
 extern whd_result_t whd_set_wsec_info_algos(whd_interface_t ifp, uint32_t algos, uint32_t mask);
 
+/** Function to get assoc request and response ie information
+ *
+ *  @param ifp             Pointer to handle instance of whd interface
+ *  @param whd_assoc_info  Pointer to the whd_assoc_info_t that recording req/resp ie and length
+ *
+ *  @return WHD_SUCCESS or Error code
+ */
+extern whd_result_t whd_get_assoc_ie_info(whd_interface_t ifp, whd_assoc_info_t *whd_assoc_info);
+
 #if defined (COMPONENT_MTB_HAL)
 /** Process interrupts function for OOB gpio pin
  *  This API is a wrapper for GPIO HAL driver's "process interrupts" function

--- a/whd-expansion/WHD/COMPONENT_WIFI6/resources/resource_imp/whd_resources.c
+++ b/whd-expansion/WHD/COMPONENT_WIFI6/resources/resource_imp/whd_resources.c
@@ -18,9 +18,9 @@
 /** @file
  * Defines WHD resource functions for BCM943340WCD1 platform
  */
-#ifndef WHD_FREERTOS
+#ifndef WHD_RTOS
 #include "cy_utils.h"
-#endif  /* WHD_FREERTOS */
+#endif  /* WHD_RTOS */
 #include "cmsis_compiler.h"
 #include "resources.h"
 #if !defined(NO_CLM_BLOB_FILE)
@@ -93,11 +93,11 @@ whd_result_t host_resource_read(whd_driver_t whd_drv, whd_resource_type_t type,
 extern const resource_hnd_t wifi_bootloader_image;
 #endif /* DOWNLOAD_RAM_BOOTLOADER */
 
-#ifndef WHD_FREERTOS
+#ifndef WHD_RTOS
 CY_ALIGN(4) unsigned char r_buffer[BLOCK_BUFFER_SIZE];
 #else
 unsigned char r_buffer[BLOCK_BUFFER_SIZE];
-#endif /* WHD_FREERTOS */
+#endif /* WHD_RTOS */
 
 #if defined(WHD_DYNAMIC_NVRAM)
 uint32_t dynamic_nvram_size = sizeof(wifi_nvram_image);

--- a/whd-expansion/WHD/COMPONENT_WIFI6/src/include/whd_wlioctl.h
+++ b/whd-expansion/WHD/COMPONENT_WIFI6/src/include/whd_wlioctl.h
@@ -1279,6 +1279,9 @@ typedef struct eventmsgs_ext
 #endif /* BUS_ENC */
 
 #define IOVAR_STR_ICMP_ECHO_REQ          "icmp_echo_req"
+#define IOVAR_STR_ASSOC_INFO             "assoc_info"
+#define IOVAR_STR_ASSOC_REQ_IES          "assoc_req_ies"
+#define IOVAR_STR_ASSOC_RESP_IES         "assoc_resp_ies"
 
 /* This value derived from the above strings, which appear maxed out in the 20s */
 #define IOVAR_NAME_STR_MAX_SIZE          32

--- a/whd-expansion/WHD/COMPONENT_WIFI6/src/whd_hal_port.c
+++ b/whd-expansion/WHD/COMPONENT_WIFI6/src/whd_hal_port.c
@@ -178,7 +178,7 @@ void whd_hal_sdio_enable_event(whd_sdio_t* sdio_obj, whd_bool_t enable)
     whd_custom_hal_sdio_irq_enable(sdio_obj, CYHAL_SDIO_CARD_INTERRUPT, enable);
 #else
     cyhal_sdio_irq_enable(sdio_obj, CYHAL_SDIO_CARD_INTERRUPT, enable);
-#endif /* WHD_CUSTOM_HAL && IMXRT */
+#endif /* WHD_CUSTOM_HAL */
 }
 #endif /* #if (CYBSP_WIFI_INTERFACE_TYPE == CYBSP_SDIO_INTERFACE) */
 

--- a/whd-expansion/WHD/COMPONENT_WIFI6/src/whd_management.c
+++ b/whd-expansion/WHD/COMPONENT_WIFI6/src/whd_management.c
@@ -423,10 +423,6 @@ whd_result_t whd_wifi_on(whd_driver_t whd_driver, whd_interface_t *ifpp)
     whd_add_primary_interface(whd_driver, ifpp);
     ifp = *ifpp;
 
-#if defined(WHD_ZEPHYR) && defined(IMXRT)
-    cy_rtos_delay_milliseconds(15000);
-#endif
-
     /* Download blob file if exists */
     retval = whd_process_clm_data(ifp);
     if (retval != WHD_SUCCESS)

--- a/whd-expansion/WHD/COMPONENT_WIFI6/src/whd_wifi_api.c
+++ b/whd-expansion/WHD/COMPONENT_WIFI6/src/whd_wifi_api.c
@@ -106,6 +106,9 @@
 #define EVTLOG_PRINT_ONLY_MODE          0x40
 #define EVTLOG_LOG_ONLY_MODE            0x80
 
+#define WL_ASSOC_INFO_MAX               512
+#define WL_EXTRA_BUF_MAX                2048
+
 /** Buffer length check for ulp statistics
  *
  *  @param buflen              buffer length
@@ -489,6 +492,63 @@ whd_result_t whd_get_bt_info(whd_driver_t whd_driver, whd_bt_info_t bt_info)
         bt_info->wlan_buf_addr = addr;
     }
     return WHD_SUCCESS;
+}
+
+whd_result_t whd_get_assoc_ie_info(whd_interface_t ifp, whd_assoc_info_t *whd_assoc_info)
+{
+    whd_result_t result;
+    wl_assoc_info_t assoc_info;
+    uint8_t *extra_buf;
+
+    CHECK_IFP_NULL(ifp);
+
+    extra_buf = (uint8_t *)whd_mem_malloc(WL_EXTRA_BUF_MAX);
+    if (!extra_buf)
+        return WHD_BUFFER_ALLOC_FAIL;
+
+    whd_mem_memset(extra_buf, 0, WL_EXTRA_BUF_MAX);
+    result = whd_wifi_get_iovar_buffer(ifp, IOVAR_STR_ASSOC_INFO, extra_buf, WL_EXTRA_BUF_MAX);
+    if (result != WHD_SUCCESS)
+        goto out;
+
+    whd_mem_memcpy(&assoc_info, extra_buf, sizeof(wl_assoc_info_t));
+    assoc_info.req_len = dtoh32(assoc_info.req_len);
+    assoc_info.resp_len = dtoh32(assoc_info.resp_len);
+    assoc_info.flags = dtoh32(assoc_info.flags);
+
+    if (assoc_info.req_len) {
+        whd_mem_memset(extra_buf, 0, WL_EXTRA_BUF_MAX);
+
+        result = whd_wifi_get_iovar_buffer(ifp, IOVAR_STR_ASSOC_REQ_IES, extra_buf, WL_ASSOC_INFO_MAX);
+        if (result != WHD_SUCCESS)
+            goto out;
+
+        whd_assoc_info->req_ies_len = assoc_info.req_len - sizeof(struct wl_dot11_assoc_req);
+        if (assoc_info.flags & WLC_ASSOC_REQ_IS_REASSOC)
+            whd_assoc_info->req_ies_len -= WHD_ETHER_ADDR_LEN;
+        whd_mem_memcpy(whd_assoc_info->req_ies, extra_buf, whd_assoc_info->req_ies_len);
+    } else {
+        whd_assoc_info->req_ies_len = 0;
+    }
+
+    if (assoc_info.resp_len) {
+        whd_mem_memset(extra_buf, 0, WL_EXTRA_BUF_MAX);
+
+        result = whd_wifi_get_iovar_buffer(ifp, IOVAR_STR_ASSOC_RESP_IES, extra_buf, WL_ASSOC_INFO_MAX);
+        if (result != WHD_SUCCESS)
+            goto out;
+
+        whd_assoc_info->resp_ies_len = assoc_info.resp_len - sizeof(struct wl_dot11_assoc_resp);
+        whd_mem_memcpy(whd_assoc_info->resp_ies, extra_buf, whd_assoc_info->resp_ies_len);
+    } else {
+        whd_assoc_info->resp_ies_len = 0;
+    }
+
+out:
+    if (extra_buf)
+        whd_mem_free(extra_buf);
+
+    return result;
 }
 
 whd_bool_t whd_wifi_platform_supports_triband(whd_interface_t ifp)
@@ -2592,6 +2652,10 @@ static void *whd_wifi_scan_events_handler(whd_interface_t ifp, const whd_event_h
     {
         /* 11 a/b/g and 20MHz bandwidth only */
         record->channel = ( ( uint8_t )(chanspec & WL_CHANSPEC_CHAN_MASK) );
+#ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT
+	/* In this case, bss_info->ctl_ch will be 0. But bss_info will be used by Zephyr, so assign channel to bss_info */
+        bss_info->ctl_ch = record->channel;
+#endif
     }
 
     /*

--- a/whd-expansion/version.xml
+++ b/whd-expansion/version.xml
@@ -1,1 +1,1 @@
-<version>Zep-1.2.1.223</version>
+<version>1.4.0.370</version>

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -61,20 +61,20 @@ blobs:
   #CYW43012 Device
   #firmware
   - path: img/whd/resources/firmware/COMPONENT_43012/43012C0.bin
-    sha256: d93bfb19971d9d061450da7c56875061be6c3f3af90e562610b648fa4c5eb45b
+    sha256: eb96440f4418fde3804edf659dc37b875b4038349f1afee40c654c5b74f910b7
     type: img
-    version: 'v1.1.0'
+    version: 'v1.4.0'
     license-path: zephyr/blobs/license.txt
-    url: https://github.com/Infineon/whd-expansion/raw/release-v1.1.0/WHD/COMPONENT_WIFI5/resources/firmware/COMPONENT_43012/43012C0.bin
+    url: https://github.com/Infineon/whd-expansion/raw/release-v1.4.0/WHD/COMPONENT_WIFI5/resources/firmware/COMPONENT_43012/43012C0.bin
     description: "Wi-Fi Firmware for CYW43012 Device"
     doc-url: https://github.com/Infineon/whd-expansion
   #firmware (mfgtest)
   - path: img/whd/resources/firmware/COMPONENT_43012/43012C0-mfgtest.bin
     sha256: 3ba133f8a22b7043a728a8511c6629a777dee11d9948461ae6a308930856f183
     type: img
-    version: 'v1.1.0'
+    version: 'v1.4.0'
     license-path: zephyr/blobs/license.txt
-    url: https://github.com/Infineon/whd-expansion/raw/release-v1.1.0/WHD/COMPONENT_WIFI5/resources/firmware/COMPONENT_43012/43012C0-mfgtest.bin
+    url: https://github.com/Infineon/whd-expansion/raw/release-v1.4.0/WHD/COMPONENT_WIFI5/resources/firmware/COMPONENT_43012/43012C0-mfgtest.bin
     description: "Wi-Fi Firmware (mfgtest) for CYW43012 Device"
     doc-url: https://github.com/Infineon/whd-expansion
   #clm for CYW943012WCD2
@@ -191,18 +191,18 @@ blobs:
   - path: img/whd/resources/firmware/COMPONENT_43022/COMPONENT_SM/43022C1.trxs
     sha256: 7426bd5f1a7537d74a16a88668f2348980e352deabb3ed713fcbb3ec885e2c6c
     type: img
-    version: 'v1.1.0'
+    version: 'v1.4.0'
     license-path: zephyr/blobs/license.txt
-    url: https://github.com/Infineon/whd-expansion/raw/release-v1.1.0/WHD/COMPONENT_WIFI5/resources/firmware/COMPONENT_43022/COMPONENT_SM/43022C1.trxs
+    url: https://github.com/Infineon/whd-expansion/raw/release-v1.4.0/WHD/COMPONENT_WIFI5/resources/firmware/COMPONENT_43022/COMPONENT_SM/43022C1.trxs
     description: "Wi-Fi Firmware for CYW43022 Device"
     doc-url: https://github.com/Infineon/whd-expansion
   #firmware (mfgtest)
   - path: img/whd/resources/firmware/COMPONENT_43022/COMPONENT_SM/43022C1-mfgtest.trxs
     sha256: a2b39b1cbe780672d4f6ae4dbf40802c1e42585ec8aa1da2651f17c76a84b7da
     type: img
-    version: 'v1.1.0'
+    version: 'v1.4.0'
     license-path: zephyr/blobs/license.txt
-    url: https://github.com/Infineon/whd-expansion/raw/release-v1.1.0/WHD/COMPONENT_WIFI5/resources/firmware/COMPONENT_43022/COMPONENT_SM/43022C1-mfgtest.trxs
+    url: https://github.com/Infineon/whd-expansion/raw/release-v1.4.0/WHD/COMPONENT_WIFI5/resources/firmware/COMPONENT_43022/COMPONENT_SM/43022C1-mfgtest.trxs
     description: "Wi-Fi Firmware (mfgtest) for CYW43022 Device"
     doc-url: https://github.com/Infineon/whd-expansion
   #clm for CYW43022CUB
@@ -229,18 +229,18 @@ blobs:
   - path: img/whd/resources/firmware/COMPONENT_4343W/4343WA1.bin
     sha256: 672f94b68bc19236c75c395f5d1be7524635c9d812f6f74585996921290bbcd1
     type: img
-    version: 'v1.1.0'
+    version: 'v1.4.0'
     license-path: zephyr/blobs/license.txt
-    url: https://github.com/Infineon/whd-expansion/raw/release-v1.1.0/WHD/COMPONENT_WIFI5/resources/firmware/COMPONENT_4343W/4343WA1.bin
+    url: https://github.com/Infineon/whd-expansion/raw/release-v1.4.0/WHD/COMPONENT_WIFI5/resources/firmware/COMPONENT_4343W/4343WA1.bin
     description: "Wi-Fi Firmware for CYW4343W (mfgtest) Device"
     doc-url: https://github.com/Infineon/whd-expansion
   #firmware (mfgtest)
   - path: img/whd/resources/firmware/COMPONENT_4343W/4343WA1-mfgtest.bin
     sha256: 00b5e0c87571b7d259c6168fb8e37c312cd011a8465a071776bef35c2a0c3cb1
     type: img
-    version: 'v1.1.0'
+    version: 'v1.4.0'
     license-path: zephyr/blobs/license.txt
-    url: https://github.com/Infineon/whd-expansion/raw/release-v1.1.0/WHD/COMPONENT_WIFI5/resources/firmware/COMPONENT_4343W/4343WA1-mfgtest.bin
+    url: https://github.com/Infineon/whd-expansion/raw/release-v1.4.0/WHD/COMPONENT_WIFI5/resources/firmware/COMPONENT_4343W/4343WA1-mfgtest.bin
     description: "Wi-Fi Firmware for CYW4343W Device"
     doc-url: https://github.com/Infineon/whd-expansion
   #clm for CY8CKIT_062
@@ -303,18 +303,18 @@ blobs:
   - path: img/whd/resources/firmware/COMPONENT_43438/43438A1.bin
     sha256: f85e3feed55c429cf2fc88316dba472647da25622bac6c07ab63807fa0ad875e
     type: img
-    version: 'v1.1.0'
+    version: 'v1.4.0'
     license-path: zephyr/blobs/license.txt
-    url: https://github.com/Infineon/whd-expansion/raw/release-v1.1.0/WHD/COMPONENT_WIFI5/resources/firmware/COMPONENT_43438/43438A1.bin
+    url: https://github.com/Infineon/whd-expansion/raw/release-v1.4.0/WHD/COMPONENT_WIFI5/resources/firmware/COMPONENT_43438/43438A1.bin
     description: "Wi-Fi Firmware for CYW43438 Device"
     doc-url: https://github.com/Infineon/whd-expansion
   #firmware (mfgtest)
   - path: img/whd/resources/firmware/COMPONENT_43438/43438A1-mfgtest.bin
     sha256: e54f2246b6b095621fb12d46ac355b854bf637f9bb8829195d622b7dae6a74f8
     type: img
-    version: 'v1.1.0'
+    version: 'v1.4.0'
     license-path: zephyr/blobs/license.txt
-    url: https://github.com/Infineon/whd-expansion/raw/release-v1.1.0/WHD/COMPONENT_WIFI5/resources/firmware/COMPONENT_43438/43438A1-mfgtest.bin
+    url: https://github.com/Infineon/whd-expansion/raw/release-v1.4.0/WHD/COMPONENT_WIFI5/resources/firmware/COMPONENT_43438/43438A1-mfgtest.bin
     description: "Wi-Fi Firmware (mfgtest) for CYW43438 Device"
     doc-url: https://github.com/Infineon/whd-expansion
   #clm for AW-CU427-P
@@ -415,18 +415,18 @@ blobs:
   - path: img/whd/resources/firmware/COMPONENT_4373/4373A0.bin
     sha256: bdd0057200ac1361f1398f0247a5eab287146b20cfa1c7c9b3e01887d25f4f62
     type: img
-    version: 'v1.1.0'
+    version: 'v1.4.0'
     license-path: zephyr/blobs/license.txt
-    url: https://github.com/Infineon/whd-expansion/raw/release-v1.1.0/WHD/COMPONENT_WIFI5/resources/firmware/COMPONENT_4373/4373A0.bin
+    url: https://github.com/Infineon/whd-expansion/raw/release-v1.4.0/WHD/COMPONENT_WIFI5/resources/firmware/COMPONENT_4373/4373A0.bin
     description: "Wi-Fi Firmware for CYW4373 Device"
     doc-url: https://github.com/Infineon/whd-expansion
   #firmware (mfgtest)
   - path: img/whd/resources/firmware/COMPONENT_4373/4373A0-mfgtest.bin
     sha256: fb7cf04274e5b7ed34d8ad53f5d619bc5337c40ec165e09d5c201174c3f7c297
     type: img
-    version: 'v1.1.0'
+    version: 'v1.4.0'
     license-path: zephyr/blobs/license.txt
-    url: https://github.com/Infineon/whd-expansion/raw/release-v1.1.0/WHD/COMPONENT_WIFI5/resources/firmware/COMPONENT_4373/4373A0-mfgtest.bin
+    url: https://github.com/Infineon/whd-expansion/raw/release-v1.4.0/WHD/COMPONENT_WIFI5/resources/firmware/COMPONENT_4373/4373A0-mfgtest.bin
     description: "Wi-Fi Firmware (mfgtest) for CYW4373 Device"
     doc-url: https://github.com/Infineon/whd-expansion
   #clm for MURATA-2AE
@@ -487,20 +487,20 @@ blobs:
   #CYW55500 Device
   #firmware
   - path: img/whd/resources/firmware/COMPONENT_55500/COMPONENT_SM/55500A1.trxcse
-    sha256: 9e4b9e143d6abe58dc43ea003adf8a2668da3468859e4dc70fc330f7da418b74
+    sha256: 5ce05434d9a88e2b053b528810bdbb91d6f5e9fe21ed2a3474bd0344895f1cc0
     type: img
-    version: 'v1.1.0'
+    version: 'v1.4.0'
     license-path: zephyr/blobs/license.txt
-    url: https://github.com/Infineon/whd-expansion/raw/release-v1.1.0/WHD/COMPONENT_WIFI6/resources/firmware/COMPONENT_55500/COMPONENT_SM/55500A1.trxcse
+    url: https://github.com/Infineon/whd-expansion/raw/release-v1.4.0/WHD/COMPONENT_WIFI6/resources/firmware/COMPONENT_55500/COMPONENT_SM/55500A1.trxcse
     description: "Wi-Fi Firmware for CYW55500 Device"
     doc-url: https://github.com/Infineon/whd-expansion
   #firmware (mfgtest)
   - path: img/whd/resources/firmware/COMPONENT_55500/COMPONENT_SM/55500A1-mfgtest.trxcse
-    sha256: 5f282c88eac9e497917a526a392238d96500bea8565040c9a02ea325093bb680
+    sha256: 381c4e436ab4963ac6b5ac8e4238607b914a31bc44db33ee8d0c175e774f65a5
     type: img
-    version: 'v1.1.0'
+    version: 'v1.4.0'
     license-path: zephyr/blobs/license.txt
-    url: https://github.com/Infineon/whd-expansion/raw/release-v1.1.0/WHD/COMPONENT_WIFI6/resources/firmware/COMPONENT_55500/COMPONENT_SM/55500A1-mfgtest.trxcse
+    url: https://github.com/Infineon/whd-expansion/raw/release-v1.4.0/WHD/COMPONENT_WIFI6/resources/firmware/COMPONENT_55500/COMPONENT_SM/55500A1-mfgtest.trxcse
     description: "Wi-Fi Firmware for CYW55500 Device"
     doc-url: https://github.com/Infineon/whd-expansion
   #clm for CYW955513SDM2WLIPA
@@ -545,18 +545,18 @@ blobs:
   - path: img/whd/resources/firmware/COMPONENT_55530/COMPONENT_SM/55530A0.trxcse
     sha256: a52e0b13bb29c21d0614be817c6574f9acf77e61b9791a112b5c3f19b52fa81e
     type: img
-    version: 'v1.1.0'
+    version: 'v1.4.0'
     license-path: zephyr/blobs/license.txt
-    url: https://github.com/Infineon/whd-expansion/raw/release-v1.1.0/WHD/COMPONENT_WIFI6/resources/firmware/COMPONENT_55530/COMPONENT_SM/55530A0.trxcse
+    url: https://github.com/Infineon/whd-expansion/raw/release-v1.4.0/WHD/COMPONENT_WIFI6/resources/firmware/COMPONENT_55530/COMPONENT_SM/55530A0.trxcse
     description: "Wi-Fi Firmware for CYW55530 Device"
     doc-url: https://github.com/Infineon/whd-expansion
   #firmware (mfgtest)
   - path: img/whd/resources/firmware/COMPONENT_55530/COMPONENT_SM/55530A0-mfgtest.trxcse
     sha256: cd1bb228c9f277fe39ac2687ec076dfb042200d076c9c0fbb367ca4d91543176
     type: img
-    version: 'v1.1.0'
+    version: 'v1.4.0'
     license-path: zephyr/blobs/license.txt
-    url: https://github.com/Infineon/whd-expansion/raw/release-v1.1.0/WHD/COMPONENT_WIFI6/resources/firmware/COMPONENT_55530/COMPONENT_SM/55530A0-mfgtest.trxcse
+    url: https://github.com/Infineon/whd-expansion/raw/release-v1.4.0/WHD/COMPONENT_WIFI6/resources/firmware/COMPONENT_55530/COMPONENT_SM/55530A0-mfgtest.trxcse
     description: "Wi-Fi Firmware for CYW55530 Device"
     doc-url: https://github.com/Infineon/whd-expansion
   #clm for CYW955530WLSDUSB
@@ -583,18 +583,18 @@ blobs:
   - path: img/whd/resources/firmware/COMPONENT_55572/COMPONENT_SM/55572A1.trxse
     sha256: 964b9abe763c63b7f65211c720d97ef2a01fe95a9c66a450b9902ecefd0842b3
     type: img
-    version: 'v1.1.0'
+    version: 'v1.4.0'
     license-path: zephyr/blobs/license.txt
-    url: https://github.com/Infineon/whd-expansion/raw/release-v1.1.0/WHD/COMPONENT_WIFI6/resources/firmware/COMPONENT_55572/COMPONENT_SM/55572A1.trxse
+    url: https://github.com/Infineon/whd-expansion/raw/release-v1.4.0/WHD/COMPONENT_WIFI6/resources/firmware/COMPONENT_55572/COMPONENT_SM/55572A1.trxse
     description: "Wi-Fi Firmware for CYW55572 Device"
     doc-url: https://github.com/Infineon/whd-expansion
   #firmware (mfgtest)
   - path: img/whd/resources/firmware/COMPONENT_55572/COMPONENT_SM/55572A1-mfgtest.trxse
     sha256: 1cda8b9bea636eba641f40945b8ec7e71e10c27e13da3c1a543f65e39169cace
     type: img
-    version: 'v1.1.0'
+    version: 'v1.4.0'
     license-path: zephyr/blobs/license.txt
-    url: https://github.com/Infineon/whd-expansion/raw/release-v1.1.0/WHD/COMPONENT_WIFI6/resources/firmware/COMPONENT_55572/COMPONENT_SM/55572A1-mfgtest.trxse
+    url: https://github.com/Infineon/whd-expansion/raw/release-v1.4.0/WHD/COMPONENT_WIFI6/resources/firmware/COMPONENT_55572/COMPONENT_SM/55572A1-mfgtest.trxse
     description: "Wi-Fi Firmware for CYW55572 Device"
     doc-url: https://github.com/Infineon/whd-expansion
   #clm for CYW955573M2IPA1


### PR DESCRIPTION
Previous version of whd-expansion is not traced as official release in github. Moving to the latest available.