### PR TITLE
zephyr-ifx-cycfg: Correct ppc tfm if/else

### DIFF
--- a/zephyr-ifx-cycfg/pse84/kit_pse84_ai/cycfg_ppc.h
+++ b/zephyr-ifx-cycfg/pse84/kit_pse84_ai/cycfg_ppc.h
@@ -23,7 +23,7 @@
 #ifndef CYCFG_PPC_H
 #define CYCFG_PPC_H
 
-#if defined(__ZEPHYR__)
+#if defined(__ZEPHYR__) && !( defined(CONFIG_BUILD_WITH_TFM) || defined(CONFIG_PSOC_EDGE_M55_SRF_SUPPORT))
 /* This file is empty. It is not needed to provide functionality, but it is needed
  * to prevent build errors in IFX assets that are expecting a file under the name
  * to exist.

--- a/zephyr-ifx-cycfg/pse84/kit_pse84_eval/cycfg_ppc.h
+++ b/zephyr-ifx-cycfg/pse84/kit_pse84_eval/cycfg_ppc.h
@@ -23,7 +23,7 @@
 #ifndef CYCFG_PPC_H
 #define CYCFG_PPC_H
 
-#if defined(__ZEPHYR__)
+#if defined(__ZEPHYR__) && !( defined(CONFIG_BUILD_WITH_TFM) || defined(CONFIG_PSOC_EDGE_M55_SRF_SUPPORT))
 /* This file is empty. It is not needed to provide functionality, but it is needed
  * to prevent build errors in IFX assets that are expecting a file under the name
  * to exist.


### PR DESCRIPTION
The cycfg_ppc.h allow for both the tfm cases and
the non tfm cases to coexist. However in the tfm
cases we need the full list of ppc settings for the correct usage of srf, so correct the check to select the right case.

Add on to https://github.com/zephyrproject-rtos/hal_infineon/pull/58 I had forgotten to push a final commit.